### PR TITLE
feat: make unit tests compatible with syskit orogen test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ cmake_minimum_required(VERSION 2.6)
 SET (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.orogen/config")
 INCLUDE(uwv_dynamic_modelBase)
 
+if (ROCK_TEST_ENABLED)
+    enable_testing()
+    find_package(Syskit REQUIRED)
+    syskit_orogen_tests(test)
+endif()
+
 # FIND_PACKAGE(KDL)
 # FIND_PACKAGE(OCL)
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -14,4 +14,6 @@
   <depend package="drivers/orogen/transformer"/>
   <depend package="control/uwv_dynamic_model"/>
   <depend package="base/numeric"/>
+
+  <test_depend package="tools/syskit" />
 </package>


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
This PR makes the uwv_dynamic_model unit tests compatible with the test suite we use for orogen packages currently.
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
